### PR TITLE
Allow writing directly to file

### DIFF
--- a/mypy2junit.py
+++ b/mypy2junit.py
@@ -69,7 +69,7 @@ def main():
 
     args = parser.parse_args()
     if args.tee and not args.output:
-        print("You must specify a --filename if using --tee")
+        print("You must specify --output if using --tee")
         return -1
 
     output, status = process_lines(

--- a/mypy2junit.py
+++ b/mypy2junit.py
@@ -1,3 +1,4 @@
+import argparse
 import fileinput
 import re
 import sys
@@ -57,13 +58,34 @@ def process_lines(lines: List[str]) -> Tuple[str, bool]:
     return output, int(result['count']) == 0
 
 
+parser = argparse.ArgumentParser()
+parser.add_argument('files', metavar='FILE', nargs='*', help='files to read, if empty, stdin is used')
+parser.add_argument('--output',
+                    type=str,
+                    dest='output',
+                    help='Filename to output to')
+parser.add_argument('--tee', action='store_true')
+
+
 def main():
+    args = parser.parse_args()
+    if args.tee and not args.filename:
+        print("You must specify a --filename if using --tee")
+        return -1
+
     output, status = process_lines(
-        list(fileinput.input())
+        list(fileinput.input(files=args.files if len(args.files) > 0 else ('-', )))
     )
-    print(
-        output
-    )
+
+    if args.output:
+        with open(args.output, 'w') as file:
+            file.write(output)
+
+    if not args.output or args.tee:
+        print(
+            output
+        )
+
     if not status:
         sys.exit(1)
 

--- a/mypy2junit.py
+++ b/mypy2junit.py
@@ -58,18 +58,17 @@ def process_lines(lines: List[str]) -> Tuple[str, bool]:
     return output, int(result['count']) == 0
 
 
-parser = argparse.ArgumentParser()
-parser.add_argument('files', metavar='FILE', nargs='*', help='files to read, if empty, stdin is used')
-parser.add_argument('--output',
-                    type=str,
-                    dest='output',
-                    help='Filename to output to')
-parser.add_argument('--tee', action='store_true')
-
-
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('files', metavar='FILE', nargs='*', help='files to read, if empty, stdin is used')
+    parser.add_argument('--output',
+                        type=str,
+                        dest='output',
+                        help='Filename to output to')
+    parser.add_argument('--tee', action='store_true')
+
     args = parser.parse_args()
-    if args.tee and not args.filename:
+    if args.tee and not args.output:
         print("You must specify a --filename if using --tee")
         return -1
 


### PR DESCRIPTION
Add `--output` and `--tee` arguments.

`--output` specifies a filename to write to
`--tee` if output is specified, also sends the results to stdout.
`--help` - shows help...

Without any arguments, the command acts exactly as it did previously, so it should be a non-breaking change.